### PR TITLE
Add a hint when the ME cannot be contacted

### DIFF
--- a/me.c
+++ b/me.c
@@ -161,7 +161,7 @@ static int mei_wait_for_me_ready(void)
 		udelay(ME_DELAY);
 	}
 
-	printf("ME: failed to become ready\n");
+	printf("ME: failed to become ready, maybe the 'mei_me' driver is not loaded.\n");
 	return -1;
 }
 


### PR DESCRIPTION
This may be because the 'mei_me' driver is not present in the kernel:

Before, without 'mei_me' driver:

Bad news, you have a `Sunrise Point-H CSME HECI #1` [...]
[...]
ME seems okay on this board
ME: failed to become ready
[...]
exiting

After loading the driver:

Bad news, you have a `Sunrise Point-H CSME HECI #1` [...]
[...]
ME seems okay on this board
[...]
ME: Firmware Version 11.6.1212.13 (code) 11.6.1212.13 (recovery) 11.6.1142.1 (fitc)
[...]
exiting

Signed-off-by: Vincent Legoll <vincent.legoll@gmail.com>